### PR TITLE
MemoryByteChannel can be closed more than once

### DIFF
--- a/src/main/java/com/github/sylvainjuge/memoryfs/MemoryByteChannel.java
+++ b/src/main/java/com/github/sylvainjuge/memoryfs/MemoryByteChannel.java
@@ -116,11 +116,19 @@ public class MemoryByteChannel implements SeekableByteChannel {
 
     @Override
     public void close() throws IOException {
-        this.open = false;
-        if (writeChannel != null)
+        if (! open) {
+          return;
+        }
+        
+        if (writeChannel != null) {
           writeChannel.close();
-        if (readChannel != null)
+        }
+        
+        if (readChannel != null) {
           readChannel.close();
+        }
+        
+        this.open = false;
     }
 
     private void checkOpen() throws ClosedChannelException {

--- a/src/main/java/com/github/sylvainjuge/memoryfs/MemoryByteChannel.java
+++ b/src/main/java/com/github/sylvainjuge/memoryfs/MemoryByteChannel.java
@@ -116,8 +116,11 @@ public class MemoryByteChannel implements SeekableByteChannel {
 
     @Override
     public void close() throws IOException {
-        checkOpen();
         this.open = false;
+        if (writeChannel != null)
+          writeChannel.close();
+        if (readChannel != null)
+          readChannel.close();
     }
 
     private void checkOpen() throws ClosedChannelException {

--- a/src/test/java/com/github/sylvainjuge/memoryfs/MemoryByteChannelTest.java
+++ b/src/test/java/com/github/sylvainjuge/memoryfs/MemoryByteChannelTest.java
@@ -53,13 +53,6 @@ public class MemoryByteChannelTest {
     }
 
     @Test(expectedExceptions = ClosedChannelException.class)
-    public void closeTwice() throws IOException {
-        MemoryByteChannel c = newReadChannel(FileData.newEmpty());
-        c.close();
-        c.close();
-    }
-
-    @Test(expectedExceptions = ClosedChannelException.class)
     public void readClosed() throws IOException {
         MemoryByteChannel c = newReadChannel(FileData.newEmpty());
         c.close();

--- a/src/test/java/com/github/sylvainjuge/memoryfs/MemoryByteChannelTest.java
+++ b/src/test/java/com/github/sylvainjuge/memoryfs/MemoryByteChannelTest.java
@@ -52,6 +52,16 @@ public class MemoryByteChannelTest {
         assertThat(c.isOpen()).isFalse();
     }
 
+    @Test
+    public void closeTwiceShouldBeFine() throws IOException {
+        MemoryByteChannel c = newReadChannel(FileData.newEmpty());
+        assertThat(c.isOpen()).isTrue();
+        c.close();
+        assertThat(c.isOpen()).isFalse();
+        c.close();
+        assertThat(c.isOpen()).isFalse();
+    }
+
     @Test(expectedExceptions = ClosedChannelException.class)
     public void readClosed() throws IOException {
         MemoryByteChannel c = newReadChannel(FileData.newEmpty());


### PR DESCRIPTION
Hello Sylvain,

I think it should be totally fine to close a ByteChannel more than once. The implementation of Files.readAllBytes(Path) is

``` java
    public static byte[] readAllBytes(Path path) throws IOException {
        try (SeekableByteChannel sbc = Files.newByteChannel(path);
             InputStream in = Channels.newInputStream(sbc)) {
            long size = sbc.size();
            if (size > (long)MAX_BUFFER_SIZE)
                throw new OutOfMemoryError("Required array size too large");

            return read(in, (int)size);
        }
    }
```

It leads to a double close. One for the InputStream and the other for the SeekableByteChannel. Please pull this patch to fix the Bug.

regards, jan
